### PR TITLE
バリデーションのロジックを変更

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -1,9 +1,7 @@
 # frozen_string_literal: true
 
-JANUARY = 1
-DECEMBER = 12
-FIRST_DAY = 1
-LAST_DAY = 31
+require 'date'
+
 MONTHS_PER_YEAR = 12
 YEARLY_COUNT = 10000
 MONTHLY_COUNT = 100
@@ -56,12 +54,12 @@ def valid?(date)
   month = date % YEARLY_COUNT / MONTHLY_COUNT
   day = date % MONTHLY_COUNT
 
-  # 月又は日が不正な値の場合
-  return false if month < JANUARY || month > DECEMBER || day < FIRST_DAY || day > LAST_DAY
-
   # 不正な年月日でないかチェックする
-  Time.new(year, month, day).strftime('%F') == \
-    "#{year.to_s.rjust(4, '0')}-#{month.to_s.rjust(2, '0')}-#{day.to_s.rjust(2, '0')}"
+  begin
+    Date.new(year, month, day)
+  rescue Date::Error
+    false
+  end
 end
 
 def calc_age(birthday, specified_date)

--- a/spec/main_spec.rb
+++ b/spec/main_spec.rb
@@ -100,86 +100,6 @@ describe 'child_age' do
   end
 
   context '入力値が不正のとき' do
-    context '誕生日が0のとき' do
-      it '誕生日が不正ですと表示される' do
-        expect do
-          child_age(0, 20230101)
-        end.to output("誕生日が不正です\n").to_stdout
-      end
-    end
-
-    context '指定日が0のとき' do
-      it '指定日が不正ですと表示される' do
-        expect do
-          child_age(20230101, 0)
-        end.to output("指定日が不正です\n").to_stdout
-      end
-    end
-
-    context '誕生月に0が入力されたとき' do
-      it '誕生日が不正ですと表示される' do
-        expect do
-          child_age(20220001, 20230101)
-        end.to output("誕生日が不正です\n").to_stdout
-      end
-    end
-
-    context '指定月に0が入力されたとき' do
-      it '指定日が不正ですと表示される' do
-        expect do
-          child_age(20220101, 20230001)
-        end.to output("指定日が不正です\n").to_stdout
-      end
-    end
-
-    context '誕生月に13が入力されたとき' do
-      it '誕生日が不正ですと表示される' do
-        expect do
-          child_age(20221301, 20230101)
-        end.to output("誕生日が不正です\n").to_stdout
-      end
-    end
-
-    context '指定月に13が入力されたとき' do
-      it '指定日が不正ですと表示される' do
-        expect do
-          child_age(20220101, 20231301)
-        end.to output("指定日が不正です\n").to_stdout
-      end
-    end
-
-    context '誕生日に0が入力されたとき' do
-      it '誕生日が不正ですと表示される' do
-        expect do
-          child_age(20220100, 20230101)
-        end.to output("誕生日が不正です\n").to_stdout
-      end
-    end
-
-    context '指定日に0が入力されたとき' do
-      it '指定日が不正ですと表示される' do
-        expect do
-          child_age(20220101, 20230100)
-        end.to output("指定日が不正です\n").to_stdout
-      end
-    end
-
-    context '誕生日に32が入力されたとき' do
-      it '誕生日が不正ですと表示される' do
-        expect do
-          child_age(20220132, 20230101)
-        end.to output("誕生日が不正です\n").to_stdout
-      end
-    end
-
-    context '指定日に32が入力されたとき' do
-      it '指定日が不正ですと表示される' do
-        expect do
-          child_age(20220101, 20230132)
-        end.to output("指定日が不正です\n").to_stdout
-      end
-    end
-
     context '誕生日に存在しない日時が入力されたとき' do
       it '誕生日が不正ですと表示される' do
         expect do
@@ -191,23 +111,7 @@ describe 'child_age' do
     context '指定日に存在しない日時が入力されたとき' do
       it '指定日が不正ですと表示される' do
         expect do
-          child_age(20220101, 20220431)
-        end.to output("指定日が不正です\n").to_stdout
-      end
-    end
-
-    context '誕生日に、存在しないうるう日が入力されたとき' do
-      it '誕生日が不正ですと表示される' do
-        expect do
-          child_age(20220229, 20230101)
-        end.to output("誕生日が不正です\n").to_stdout
-      end
-    end
-
-    context '指定日に、存在しないうるう日が入力されたとき' do
-      it '指定日が不正ですと表示される' do
-        expect do
-          child_age(20220101, 20220229)
+          child_age(20220101, 20221331)
         end.to output("指定日が不正です\n").to_stdout
       end
     end


### PR DESCRIPTION
実装中は、エラーを吐くDateクラスより、エラーを吐かないTimeクラスの方が良いように思い、Timeクラスを使ったが、
後から考えるとDateクラスを使った方が定数もテストコードも減らせるので、Dateクラスを使う方が良いように思う。
```
irb(main):003:0> Time.new(2001,2,29)
=> 2001-03-01 00:00:00 +0900
irb(main):004:0>
irb(main):005:0> require 'date'
=> false
irb(main):006:0> Date.new(2001,2,29)
(irb):6:in `initialize': invalid date (Date::Error)
        from (irb):6:in `new'
        from (irb):6:in `<main>'
        from /home/kei-kmj/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
        from /home/kei-kmj/.rbenv/versions/3.2.2/bin/irb:25:in `load'
        from /home/kei-kmj/.rbenv/versions/3.2.2/bin/irb:25:in `<main>'
```